### PR TITLE
Fix: Keep track of pam_handle_t pointer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 OUTPUT := .output
 BIN := bin
-CLANG ?= clang-11
-LLVM_STRIP ?= llvm-strip-11
+CLANG ?= clang
+LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= /usr/sbin/bpftool
 LIBBPF_SRC := $(abspath ../libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)

--- a/src/pamspy.c
+++ b/src/pamspy.c
@@ -279,7 +279,14 @@ int main(int argc, char **argv)
         goto cleanup;
     }
     
-    // Attach userland probe 
+    // Attach userland probes
+    skel->links.get_addr_pam_get_authtok = bpf_program__attach_uprobe(
+        skel->progs.get_addr_pam_get_authtok,
+		false,           /* uprobe */
+		-1,             /* any pid */
+		env.libpam_path,       /* path to the lib*/
+		offset
+    );
     skel->links.trace_pam_get_authtok = bpf_program__attach_uprobe(
         skel->progs.trace_pam_get_authtok,
 		true,           /* uretprobe */


### PR DESCRIPTION
This pull request fixes the untracked `pam_handle_t` structure pointer leading into a wrong memory read on `pam_get_authtok` return.

It also unreferences the hardcoded Makefile clang version.